### PR TITLE
openPMD: Fix Reader of Scalar Records

### DIFF
--- a/postpic/datareader/openPMDh5.py
+++ b/postpic/datareader/openPMDh5.py
@@ -88,12 +88,18 @@ class OpenPMDreader(Dumpreader_ifc):
 
     def gridoffset(self, key, axis):
         axid = helper.axesidentify[axis]
-        attrs = self[key].parent.attrs
+        if "gridUnitSI" in self[key].attrs:
+            attrs = self[key].attrs
+        else:
+            attrs = self[key].parent.attrs
         return attrs['gridGlobalOffset'][axid] * attrs['gridUnitSI']
 
     def gridspacing(self, key, axis):
         axid = helper.axesidentify[axis]
-        attrs = self[key].parent.attrs
+        if "gridUnitSI" in self[key].attrs:
+            attrs = self[key].attrs
+        else:
+            attrs = self[key].parent.attrs
         return attrs['gridSpacing'][axid] * attrs['gridUnitSI']
 
     def gridpoints(self, key, axis):


### PR DESCRIPTION
For scalar openPMD `records` such as a temperature field, a particle charge attribute, etc. the `record` itself is identical to its `record component`.

This commit fixes the detection of `record` attributes specific to fields (meshes) by checking either on the `record component` (scalar records) and if the attribute is not found there at the `parent` group (for vector records) level.