### PR TITLE
Dev

### DIFF
--- a/postpic/datareader/datareader.py
+++ b/postpic/datareader/datareader.py
@@ -197,15 +197,17 @@ class Dumpreader_ifc(with_metaclass(abc.ABCMeta, FieldAnalyzer)):
     def gridkeyB(self, component, **kwargs):
         return self._keyB(component, **kwargs)
 
-    def simgridkeys(self):
+    def _simgridkeys(self):
         '''
         returns a list of keys that can be tried one after another to determine the grid,
         that the actual simulations was running on.
+        This is dirty. Rather override self.simgridpoints and self.simextent
+        with your own (better performance) implementation.
         '''
         return []
 
     def simgridpoints(self, axis):
-        for key in self.simgridkeys():
+        for key in self._simgridkeys():
             try:
                 return self.gridpoints(key, axis)
             except(KeyError):
@@ -214,9 +216,10 @@ class Dumpreader_ifc(with_metaclass(abc.ABCMeta, FieldAnalyzer)):
 
     def simextent(self, axis):
         '''
-        returns the extent of the actual simulation window
+        returns the extent of the actual simulation box.
+        Override in your own reader class for better performance implementation.
         '''
-        for key in self.simgridkeys():
+        for key in self._simgridkeys():
             try:
                 offset = self.gridoffset(key, axis)
                 n = self.gridpoints(key, axis)

--- a/postpic/datareader/datareader.py
+++ b/postpic/datareader/datareader.py
@@ -226,7 +226,7 @@ class Dumpreader_ifc(with_metaclass(abc.ABCMeta, FieldAnalyzer)):
                 return np.array([offset, offset + self.gridspacing(key, axis) * n])
             except(KeyError):
                 pass
-        raise KeyError
+        raise KeyError('Unable to resolve "simexent" for axis "{:}"'.format(axis))
 
     # --- Particle Data ---
     @abc.abstractmethod

--- a/postpic/datareader/dummy.py
+++ b/postpic/datareader/dummy.py
@@ -127,6 +127,13 @@ class Dummyreader(Dumpreader_ifc):
     def _keyB(self, component):
         return component
 
+    def simgridpoints(self, axis):
+        return self.grid(None, axis)
+
+    def simextent(self, axis):
+        g = self.grid(None, axis)
+        return np.asfarray([g[0], g[-1]])
+
     def gridnode(self, key, axis):
         '''
         Args:

--- a/postpic/datareader/epochsdf.py
+++ b/postpic/datareader/epochsdf.py
@@ -120,7 +120,7 @@ class Sdfreader(Dumpreader_ifc):
 
     def simextent(self, axis):
         '''
-        Returns the extent of the actual simulation window.
+        Returns the extent of the actual simulation box.
         '''
         m = self['Grid/Grid']
         extents = m.extents
@@ -214,27 +214,3 @@ class Visitreader(Simulationreader_ifc):
 
     def __str__(self):
         return '<Visitreader at "' + self.visitfile + '">'
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/postpic/datareader/openPMDh5.py
+++ b/postpic/datareader/openPMDh5.py
@@ -118,7 +118,7 @@ class OpenPMDreader(Dumpreader_ifc):
         '''
         the number of spatial dimensions the simulation was using.
         '''
-        for k in self.simgridkeys():
+        for k in self._simgridkeys():
             try:
                 gs = self.gridspacing(k, None)
                 return len(gs)
@@ -134,7 +134,7 @@ class OpenPMDreader(Dumpreader_ifc):
         axsuffix = {0: 'x', 1: 'y', 2: 'z'}[helper.axesidentify[component]]
         return 'fields/B/' + axsuffix
 
-    def simgridkeys(self):
+    def _simgridkeys(self):
         return ['fields/E/x', 'fields/E/y', 'fields/E/z',
                 'fields/B/x', 'fields/B/y', 'fields/B/z']
 

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -303,10 +303,7 @@ class MultiSpecies(object):
             return None
 
     def simextent(self, axis):
-        try:
-            return self.dumpreader.simextent(axis)
-        except(AttributeError, KeyError):
-            return None
+        return None
 
     def simgridpoints(self, axis):
         try:

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -303,11 +303,22 @@ class MultiSpecies(object):
             return None
 
     def simextent(self, axis):
-        return None
+        '''
+        the combined simextent for all species and dumps included in this MultiSpecies object.
+        '''
+        extents = np.asarray([ssa.dumpreader.simextent(axis) for ssa in self._ssas])
+        mins = np.min(extents, axis=0)[::2]
+        maxs = np.max(extents, axis=0)[1::2]
+        return np.asarray([mins, maxs]).T.flatten()
 
     def simgridpoints(self, axis):
+        '''
+        this function is for convenience only and is likely to be removed in the future.
+        Particlarly it is impossible to define the grid of the simulation if the
+        MultiSpecies object consists of multiple dumps from different simulations.
+        '''
         try:
-            return self.dumpreader.simgridpoints(axis)
+            ret = self._ssas[0].dumpreader.simgridpoints(axis)
         except(AttributeError, KeyError):
             return None
 
@@ -896,10 +907,10 @@ class MultiSpecies(object):
         else:
             xdata = self(spx)
         if simextent:
-            tmp = self.simextent(getattr(spx, 'symbol', None))
+            tmp = self.simextent(getattr(spx, 'symbol', spx))
             rangex = tmp if tmp is not None else rangex
         if simgrid:
-            tmp = self.simgridpoints(getattr(spx, 'symbol', None))
+            tmp = self.simgridpoints(getattr(spx, 'symbol', spx))
             if tmp is not None:
                 optargsh['bins'] = tmp
         if len(xdata) == 0:
@@ -959,13 +970,13 @@ class MultiSpecies(object):
         # ist die Gesamtteilchenzahl falsch berechnet, weil die Teilchen die
         # ausserhalb des sichtbaren Bereiches liegen mitgezaehlt werden.
         if simextent:
-            tmp = self.simextent(getattr(spx, 'symbol', None))
+            tmp = self.simextent(getattr(spx, 'symbol', spx))
             rangex = tmp if tmp is not None else rangex
-            tmp = self.simextent(getattr(spy, 'symbol', None))
+            tmp = self.simextent(getattr(spy, 'symbol', spy))
             rangey = tmp if tmp is not None else rangey
         if simgrid:
             for i, sp in enumerate([spx, spy]):
-                tmp = self.simgridpoints(getattr(spx, 'symbol', None))
+                tmp = self.simgridpoints(getattr(sp, 'symbol', sp))
                 if tmp is not None:
                     optargsh['bins'][i] = tmp
         if len(xdata) == 0:
@@ -1036,15 +1047,15 @@ class MultiSpecies(object):
         # ist die Gesamtteilchenzahl falsch berechnet, weil die Teilchen die
         # ausserhalb des sichtbaren Bereiches liegen mitgezaehlt werden.
         if simextent:
-            tmp = self.simextent(getattr(spx, 'symbol', None))
+            tmp = self.simextent(getattr(spx, 'symbol', spx))
             rangex = tmp if tmp is not None else rangex
-            tmp = self.simextent(getattr(spy, 'symbol', None))
+            tmp = self.simextent(getattr(spy, 'symbol', spy))
             rangey = tmp if tmp is not None else rangey
-            tmp = self.simextent(getattr(spz, 'symbol', None))
+            tmp = self.simextent(getattr(spz, 'symbol', spz))
             rangez = tmp if tmp is not None else rangez
         if simgrid:
             for i, sp in enumerate([spx, spy, spz]):
-                tmp = self.simgridpoints(getattr(spx, 'symbol', None))
+                tmp = self.simgridpoints(getattr(sp, 'symbol', sp))
                 if tmp is not None:
                     optargsh['bins'][i] = tmp
         if len(xdata) == 0:


### PR DESCRIPTION
fix the `simgridpoints` and the `simextent` function when used with the new particle interface. Since the old particle interface using functions is deprecated, the compatibility to that will be dropped.