### PR TITLE
Ku/refactor multi species

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ python:
   - "3.5"
   - "3.6"
 
+matrix:
+  allow_failures:
+    - python: "3.5"
+
 # Install conda
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog of postpic
 
 ## current master
-2017-10-10
 
-**Incompatible adjustments to last version**
-* `postpic.Field` method transform is renamed to `map_coordinates`, matching the underlying scipy-function.
+**Incompatible adjustments to previous version**
+* `postpic.Field` method `transform` is renamed to `map_coordinates`, matching the underlying scipy-function.
 * `postpic.Field.map_coordinates` applies now the Jacobian determinant of the transformation, in order to preserve the definite integral.
-
 In your code you will need to turn calls to `Field.transform` into calls to `Field.map_coordinates` and set the keyword argument `preserve_integral=False` to get the old behaviour.
+* The functions `MultiSpecies.compress`, `MultiSpecies.filter` and `MultiSpecies.uncompress` return a new MultiSpecies object. Before this release, they modified the current object. Assuming  `ms` is a `MultiSpecies` object, the corresponding adjustemens read:  
+**old**: `ms.filter('gamma > 2')`  
+**new**: `ms = ms.filter('gamma > 2')`
 
 **Other improvements and new features**
 * `postpic` has a new function `time_profile_at_plane` that 'measures' the temporal profile of a pulse while passing through a plane
@@ -36,7 +37,7 @@ Many improvements in terms of speed and features. Unfortunately some changes are
 * `postpic.Field` properly handles operator overloading and slicing. Slicing can be index based (integers) or referring the actual physical extent on the axis of a Field object (using floats).
 * Expression based interface to particle properties (see below)
 
-**Incompatible adjustments to last version**
+**Incompatible adjustments to previous version**
 * New dependency: Postpic requires the `numexpr` package to be installed now.
 * Expression based interface of for particles: If `ms` is a `postpic.MultiSpecies` object, then the call `ms.X()` has been deprecated. Use `ms('x')` instead. This new particle interface can handle expressions that the `numexpr` package understands. Also `ms('sqrt(x**2 + gamma - id)')` is valid. This interface is easier to use, has better functionality and is faster due to `numexpr`.
 The list of known per particle scalars and their definitions is available at `postpic.particle_scalars`. In addition all constants of `scipy.constants.*` can be used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * `postpic.Field` method `transform` is renamed to `map_coordinates`, matching the underlying scipy-function.
 * `postpic.Field.map_coordinates` applies now the Jacobian determinant of the transformation, in order to preserve the definite integral.
 In your code you will need to turn calls to `Field.transform` into calls to `Field.map_coordinates` and set the keyword argument `preserve_integral=False` to get the old behaviour.
-* The functions `MultiSpecies.compress`, `MultiSpecies.filter` and `MultiSpecies.uncompress` return a new MultiSpecies object. Before this release, they modified the current object. Assuming  `ms` is a `MultiSpecies` object, the corresponding adjustemens read:  
+* The functions `MultiSpecies.compress`, `MultiSpecies.filter`, `MultiSpecies.uncompress` and `ParticleHistory.skip` return a new object now. Before this release, they modified the current object. Assuming  `ms` is a `MultiSpecies` object, the corresponding adjustemens read:  
 **old**: `ms.filter('gamma > 2')`  
 **new**: `ms = ms.filter('gamma > 2')`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 * `postpic.Field` method `transform` is renamed to `map_coordinates`, matching the underlying scipy-function.
 * `postpic.Field.map_coordinates` applies now the Jacobian determinant of the transformation, in order to preserve the definite integral.
 In your code you will need to turn calls to `Field.transform` into calls to `Field.map_coordinates` and set the keyword argument `preserve_integral=False` to get the old behaviour.
-* The functions `MultiSpecies.compress`, `MultiSpecies.filter`, `MultiSpecies.uncompress` and `ParticleHistory.skip` return a new object now. Before this release, they modified the current object. Assuming  `ms` is a `MultiSpecies` object, the corresponding adjustemens read:  
-**old**: `ms.filter('gamma > 2')`  
-**new**: `ms = ms.filter('gamma > 2')`
+* The functions `MultiSpecies.compress`, `MultiSpecies.filter`, `MultiSpecies.uncompress` and `ParticleHistory.skip` return a new object now. Before this release, they modified the current object. Assuming  `ms` is a `MultiSpecies` object, the corresponding adjustemens read:<br>
+old: `ms.filter('gamma > 2')`<br>
+new: `ms = ms.filter('gamma > 2')`
 
 **Other improvements and new features**
 * `postpic` has a new function `time_profile_at_plane` that 'measures' the temporal profile of a pulse while passing through a plane

--- a/examples/simpleexample.py
+++ b/examples/simpleexample.py
@@ -116,11 +116,11 @@ def main():
             # cf.name = 'x>0.0'
             # pa.compress(cf)
             # nicer is the new filter function, which does exactly the same:
-            pa.filter('x>0')
+            pf = pa.filter('x>0')
             # plot 15, compare with plot 10
-            plotter.plotField(pa.createField('x', 'y', optargsh={'bins': [1000,1000]}))
+            plotter.plotField(pf.createField('x', 'y', optargsh={'bins': [1000,1000]}))
             # plot 16, compare with plot 12
-            plotter.plotField(pa.createField('p_perp', 'r_xy', optargsh={'bins':[400,400]}))
+            plotter.plotField(pf.createField('p_perp', 'r_xy', optargsh={'bins':[400,400]}))
 
             plotter.plotField(dr.divE())  # plot 13
 

--- a/postpic/datareader/epochsdf.py
+++ b/postpic/datareader/epochsdf.py
@@ -204,7 +204,7 @@ class Sdfreader(Dumpreader_ifc):
         try:
             ret = options[attribid](species)
         except(IndexError):
-            raise KeyError
+            raise KeyError('Attribute "{}" of species "{}" not found.'.format(attrib, species))
         return ret
 
     def getderived(self):

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -536,7 +536,7 @@ class MultiSpecies(object):
         '''
         ret = copy.copy(self)
         ret._compresslog = []
-        ret._ssas = [s.uncompress for s in self._ssas]
+        ret._ssas = [s.uncompress() for s in self._ssas]
         return ret
 
     def getcompresslog(self):

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -429,7 +429,7 @@ class MultiSpecies(object):
     def add(self, dumpreader, species, ignore_missing_species=False):
         '''
         adds a species to this MultiSpecies.
-        This function modifies the current Object.
+        This function modifies the current Object and always returns None.
 
         Attributes
         ----------
@@ -497,6 +497,8 @@ class MultiSpecies(object):
         like compress, but takes a ScalarProperty or a str, which are required to
         evaluate to a boolean list to filter particles. This is the preferred method to
         filter particles by a value of their property.
+
+        Returns a new MultiSpecies instance.
         '''
         if isinstance(condition, ScalarProperty):
             sp = condition
@@ -510,6 +512,8 @@ class MultiSpecies(object):
     def compress(self, condition, name='unknown condition'):
         """
         works like numpy.compress.
+        Returns a new MultiSpecies instance.
+
         Additionaly you can specify a name, that gets saved in the compresslog.
 
         condition has to be one out of:
@@ -548,6 +552,8 @@ class MultiSpecies(object):
         '''
         like "compress", but accepts a function.
 
+        Returns a new MultiSpecies instance.
+
         **kwargs
         --------
         name -- name the condition.
@@ -558,7 +564,8 @@ class MultiSpecies(object):
 
     def uncompress(self):
         '''
-        undo all previous calls of "compress".
+        Returns a new MultiSpecies instance, with all previous calls of
+        "compress" or "filter" undone.
         '''
         ret = copy.copy(self)
         ret._compresslog = []

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -1286,6 +1286,17 @@ class ParticleHistory(object):
         # lookup dict used by collect
         self._updatelookupdict()
 
+    def __copy__(self):
+        '''
+        returns a shallow copy of the object.
+        This method is called by `copy.copy(obj)`.
+        '''
+        cls = type(self)
+        ret = cls.__new__(cls)
+        ret.__dict__.update(self.__dict__)
+        # _updatelookupdict creates a new _id2i dictionary. Therefore no need to copy that here.
+        return ret
+
     def _updatelookupdict(self):
         '''
         updates `self._id2i`.
@@ -1330,8 +1341,10 @@ class ParticleHistory(object):
         '''
         takes only everth (n+1)-th particle
         '''
-        self.ids = self.ids[::n+1]
-        self._updatelookupdict()
+        ret = copy.copy(self)
+        ret.ids = self.ids[::n+1]
+        ret._updatelookupdict()
+        return ret
 
     def collect(self, *scalarfs):
         '''

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -230,6 +230,15 @@ class _SingleSpecies(object):
                 pass
         return ret
 
+    def initial_npart(self):
+        '''
+        return the original number of particles.
+        '''
+        if self._compressboollist is None:
+            return len(self)
+        else:
+            return len(self._compressboollist)
+
     # --- The Interface for particle properties using __call__ ---
 
     def _eval_single_sp(self, sp, _vars=None):
@@ -311,8 +320,14 @@ class MultiSpecies(object):
         return ret
 
     def __str__(self):
-        return '<MultiSpecies including ' + str(self.species) \
-            + '(' + str(len(self)) + ')>'
+        n = len(self)
+        i = self.initial_npart
+        if n == i:
+            return '<MultiSpecies including "' + str(self.species) + '"' \
+                + '({})>'.format(n)
+        else:
+            return '<MultiSpecies including "' + str(self.species) + '"' \
+                + '({}/{} -- {:.2f}%)>'.format(n, i, n/i*100)
 
     @property
     def dumpreader(self):
@@ -357,6 +372,16 @@ class MultiSpecies(object):
         ret = 0
         for ssa in self._ssas:
             ret += len(ssa)
+        return ret
+
+    @property
+    def initial_npart(self):
+        '''
+        Original number of particles (before the use of compression or filter).
+        '''
+        ret = 0
+        for ssa in self._ssas:
+            ret += ssa.initial_npart()
         return ret
 
     @property

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -67,7 +67,8 @@ class _SingleSpecies(object):
     2) a single scalar value if this property is equal for the entire
     species (as usual for 'mass' or 'charge').
     3) raise a KeyError on request if the property wasnt dumped.
-    This class is immutable.
+    Once initiated, all implemented methods leave the object unchanged.
+    A new instance is returned if needed.
     """
     # List of atomic particle properties. Those will be requested from the dumpreader
     # All other particle properties will be calculated from these.

--- a/test/test_particles.py
+++ b/test/test_particles.py
@@ -33,19 +33,16 @@ class TestMultiSpecies(unittest.TestCase):
     def test_compress(self):
         def cf(ms):
             return ms('x>0')
-        self.p.compressfn(cf)
-        lencf = len(self.p)
-        self.p.uncompress()
-        self.p.filter('x>0')
-        lenf = len(self.p)
-        self.p.uncompress()
+        p2 = self.p.compressfn(cf)
+        lencf = len(p2)
+        p3 = self.p.filter('x>0')
+        lenf = len(p3)
         self.assertEqual(lencf, lenf)
 
     def test_compress_ids(self):
         ids = [1,5,10]
-        self.p.compress(ids)
-        lenc = len(self.p)
-        self.p.uncompress()
+        p2 = self.p.compress(ids)
+        lenc = len(p2)
         self.assertEqual(lenc, 3)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The functions `MultiSpecies.compress`, `MultiSpecies.filter`, `MultiSpecies.uncompress` and `ParticleHistory.skip` return a new object now. Before this release, they modified the current object. Assuming  `ms` is a `MultiSpecies` object, the corresponding adjustemens read:<br>
old: `ms.filter('gamma > 2')`<br>
new: `ms = ms.filter('gamma > 2')`