### PR TITLE
Multiple Fixes for old Numpy/Scipy

### DIFF
--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -882,7 +882,7 @@ class Field(object):
 
             shape = [1]*field.dimensions
             shape[axis] = m
-            windows.append(np.reshape(sps.tukey(m, 1-ll/m), shape))
+            windows.append(np.reshape(helper.tukey(m, 1-ll/m), shape))
 
         field = field[slices]
         varnames = "abcdefg"

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -422,7 +422,7 @@ class Field(object):
         return np.squeeze([a.grid for a in self.axes])
 
     def meshgrid(self, sparse=True):
-        return np.meshgrid(*[ax.grid for ax in self.axes], indexing='ij', sparse=sparse)
+        return helper.meshgrid(*[ax.grid for ax in self.axes], indexing='ij', sparse=sparse)
 
     @property
     def dimensions(self):

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1139,8 +1139,21 @@ class Field(object):
         # normalization factor ensuring Parseval's Theorem
         fftnorm = np.sqrt(V/Vk)
 
+        # compile fft arguments, starting from default arguments `fft_kwargs` ...
         my_fft_args = fft_kwargs.copy()
+        # ... and adding the user supplied `kwargs`
         my_fft_args.update(kwargs)
+        # ... and also norm = 'ortho'
+        my_fft_args['norm'] = 'ortho'
+
+        # Workaround for missing `fft` argument `norm='ortho'`
+        from pkg_resources import parse_version
+        if parse_version(np.__version__) < parse_version('1.10'):
+            del my_fft_args['norm']
+            if transform_state is False:
+                fftnorm /= np.sqrt(N)
+            elif transform_state is True:
+                fftnorm *= np.sqrt(N)
 
         mat = self.matrix
 
@@ -1155,8 +1168,7 @@ class Field(object):
                 for i in axes
             }
             mat = fftnorm \
-                * fft.fftshift(fft.fftn(mat, axes=axes, norm='ortho', **my_fft_args),
-                               axes=axes)
+                * fft.fftshift(fft.fftn(mat, axes=axes, **my_fft_args), axes=axes)
 
         # ... or transforming from frequency domain to spatial domain
         elif transform_state is True:
@@ -1166,8 +1178,7 @@ class Field(object):
                 for i in axes
             }
             mat = fftnorm \
-                * fft.ifftn(fft.ifftshift(mat, axes=axes), axes=axes, norm='ortho',
-                            **my_fft_args)
+                * fft.ifftn(fft.ifftshift(mat, axes=axes), axes=axes, **my_fft_args)
 
         if exponential_signs == 'temporal':
             mat = np.conjugate(mat)

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -705,7 +705,7 @@ class Field(object):
         coordinates_px = [ax.value_to_index(x) for ax, x in zip(self.axes, coordinates_ax)]
 
         # Broadcast all coordinate arrays to the new shape
-        coordinates_px = [np.broadcast_to(c, shape) for c in coordinates_px]
+        coordinates_px = [helper.broadcast_to(c, shape) for c in coordinates_px]
 
         # Map the matrix using scipy.ndimage.map_coordinates
         if np.isrealobj(self.matrix):

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -316,6 +316,19 @@ class SpeciesIdentifier(PhysicalConstants):
 
 
 # Some static functions
+def meshgrid(*args, **kwargs):
+    from pkg_resources import parse_version
+    if len(args) < 2 and parse_version(np.__version__) < parse_version('1.9'):
+        if len(args) == 0:
+            return tuple()
+
+        # if we are here, that means len(args)==1
+        if kwargs.get('copy', False):
+            return (args[0].copy(),)
+        return (args[0].view(),)
+    return np.meshgrid(*args, **kwargs)
+
+
 def polar2linear(theta, r):
     x = r*np.cos(theta)
     y = r*np.sin(theta)
@@ -662,7 +675,7 @@ def _linear_interpolation_frequency_response_on_k(lin_response_omega, k_axes, om
     """
     from . import datahandling
 
-    kmesh = np.meshgrid(*[ax.grid for ax in k_axes], indexing='ij', sparse=True)
+    kmesh = meshgrid(*[ax.grid for ax in k_axes], indexing='ij', sparse=True)
 
     resp_mat = abs(lin_response_omega(omega_func(kmesh)))
 
@@ -807,7 +820,7 @@ def kspace(component, fields, extent=None, interpolation=None, omega_func=omega_
     # print('result_origin', result_origin, Dx, dx)
 
     # calculate the k mesh and k^2
-    mesh = np.meshgrid(*[ax.grid for ax in result.axes], indexing='ij', sparse=True)
+    mesh = meshgrid(*[ax.grid for ax in result.axes], indexing='ij', sparse=True)
     k2 = sum(ki**2 for ki in mesh)
 
     # calculate omega, either using the vacuum expression or omega_func()
@@ -937,7 +950,7 @@ def linear_phase(field, dx):
             axes[i] -= axes[i][0]
 
     # build mesh
-    mesh = np.meshgrid(*axes, indexing='ij', sparse=True)
+    mesh = meshgrid(*axes, indexing='ij', sparse=True)
 
     # prepare mesh for numexpr-dict
     kdict = {'k{}'.format(i): k for i, k in enumerate(mesh)}

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -85,7 +85,7 @@ class TestField(unittest.TestCase):
         m = np.reshape(np.arange(60), (4, 5, 3))
         self.f3d = dh.Field(m)
 
-        x, y = np.meshgrid(np.linspace(0,2*np.pi,100), np.linspace(0,2*np.pi,100), indexing='ij', sparse=True)
+        x, y = helper.meshgrid(np.linspace(0,2*np.pi,100), np.linspace(0,2*np.pi,100), indexing='ij', sparse=True)
         self.f2d_fine = dh.Field(np.sin(x)*np.cos(y))
 
     def checkFieldConsistancy(self, field):


### PR DESCRIPTION
* Field: Fix `fft` for numpy < 1.10
* Fix use of np.meshgrid for numpy < 1.9
* Field: Fixed autocutout for scipy < 0.16
* Fixed use of np.broadcast_to for numpy<1.10
* Fix np.moveaxis for np<1.10