### PR TITLE
No need to override __del__ if you don't do anything special

### DIFF
--- a/postpic/datareader/epochsdf.py
+++ b/postpic/datareader/epochsdf.py
@@ -82,9 +82,6 @@ class Sdfreader(Dumpreader_ifc):
             raise IOError('File "' + str(sdffile) + '" doesnt exist.')
         self._data = sdf.read(sdffile, dict=True)
 
-    def __del__(self):
-        del self._data
-
 # --- Level 0 methods ---
 
     def keys(self):


### PR DESCRIPTION
This also fixes a 'Exception ignored in: <bound method Sdfreader.__del__ >' when self._data = sdf.read(sdffile, dict=True) fails with a OSError'