### PR TITLE
bugfix `Field.sqeeze` for shapes containing 0 length

### DIFF
--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1263,10 +1263,13 @@ class Field(NDArrayOperatorsMixin):
         '''
         removes axes that have length 1, reducing self.dimensions.
 
+        Note, that axis with length 0 will not be removed! `numpy.squeeze` also does not
+        remove length=0 directions.
+
         Same as `numpy.squeeze`.
         '''
         ret = copy.copy(self)
-        retained_axes = [i for i in range(self.dimensions) if len(self.axes[i]) > 1]
+        retained_axes = [i for i in range(len(self.shape)) if len(self.axes[i]) != 1]
 
         ret.axes = [self.axes[i] for i in retained_axes]
         ret.axes_transform_state = [self.axes_transform_state[i] for i in retained_axes]

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -262,11 +262,17 @@ class Axis(object):
         if isinstance(index, slice):
             if any(helper.is_non_integer_real_number(x) for x in (index.start, index.stop)):
                 if index.step is not None:
-                    raise IndexError('Non-Integer slices should have step == None')
+                    raise IndexError('Non-Integer slices must have step == None')
                 return self._extent_to_slice((index.start, index.stop))
             return index
         else:
             if helper.is_non_integer_real_number(index):
+                # Indexing to a single position outside the extent
+                # will yield IndexError. Identical behaviour as numpy.ndarray
+                if index < self.extent[0] or index > self.extent[1]:
+                    msg = 'Physical index position {} is outside of the ' \
+                          'extent {} of axis {}'.format(index, self.extent, str(self))
+                    raise IndexError(msg)
                 index = helper.find_nearest_index(self.grid, index)
             return slice(index, index+1)
 
@@ -291,7 +297,7 @@ class Axis(object):
         return self._n
 
     def __str__(self):
-        return '<Axis "' + str(self.name) + '" (' + str(len(self)) + ' grid points)'
+        return '<Axis "' + str(self.name) + '" (' + str(len(self)) + ' grid points)>'
 
 
 def _reducing_numpy_method(method):

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import unittest
 import postpic.datahandling as dh
@@ -146,7 +146,14 @@ class TestField(unittest.TestCase):
         self.assertEqual(self.f2d[0.5:, :].matrix.shape, (2, 5))
 
         self.assertEqual(self.f3d[0.5:, :, 0.5].matrix.shape, (2, 5, 1))
-        self.assertEqual(self.f3d[0.5:, :, 0.5].squeeze().matrix.shape, (2, 5))
+
+    def test_squeeze(self):
+        s = self.f3d[0.5:, :, 0.5].squeeze().shape
+        self.assertEqual(s, (2, 5))
+        s = self.f3d[1.5:2, :, :].squeeze().shape
+        self.assertEqual(s, (0, 5, 3))
+        s = self.f3d[1.5:2, 0.3, :].squeeze().shape
+        self.assertEqual(s, (0, 3))
 
     def test_transpose(self):
         f3d_T = self.f3d.T

--- a/test/test_dumpreader.py
+++ b/test/test_dumpreader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import unittest
 import postpic.datareader as da

--- a/test/test_field_calc.py
+++ b/test/test_field_calc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import unittest
 import postpic as pp

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import unittest
 import postpic as pp

--- a/test/test_particles.py
+++ b/test/test_particles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import unittest
 import postpic as pp

--- a/test/test_particlestogrid.py
+++ b/test/test_particlestogrid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # This file is part of postpic.


### PR DESCRIPTION
* Tests are added for the specific cases. 
* The Field will now raise an `IndexError` if an index is outside the physical extent (using physical indexing). Before this commit it was always using the nearest grid point, even if that is clearly far away.