### PR TITLE
Fix #144

### DIFF
--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -95,7 +95,6 @@ try:
     import pyfftw.interfaces.cache as fftw_cache
     import pyfftw.interfaces.numpy_fft as fftw
     fftw_cache.enable()
-    fftw_cache.set_keepalive_time(3600)
     fft = fftw
     fft_kwargs = dict(planner_effort='FFTW_ESTIMATE', threads=nproc)
 except ImportError:


### PR DESCRIPTION
Leave the keep-alive time of the fftw cache at the default value. The cache is meant only for quick repetitions of very small transforms. Planner wisdom is accumulated also without this cache. https://hgomersall.github.io/pyFFTW/pyfftw/interfaces/interfaces.html#module-pyfftw.interfaces.cache