### PR TITLE
travis: change libgfortran==1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     # ubuntu 14.04.5 LTS:
     # python 2.6 is explicitly NOT supported!
     - python: 3.4
-      env: MATPLOTLIB_V=1.3.1 NUMPY_V=1.8.1 SCIPY_V=0.13.3 CYTHON_V=0.20.1 EXTRAPACK="libgfortran==1"
+      env: MATPLOTLIB_V=1.3.1 NUMPY_V=1.8.1 SCIPY_V=0.13.3 CYTHON_V=0.20.1 EXTRAPACK="libgfortran<3"
     # ubuntu 16.04.3 LTS:
     - python: 2.7
       env: MATPLOTLIB_V=1.5.1 NUMPY_V=1.11.0 SCIPY_V=0.17.0 CYTHON_V=0.23.4


### PR DESCRIPTION
tranvis suddenly yields an error on this command. Changing to libgfortran<1 magically helps. However, the may be the option to change to `libgfortran-ng` instead....