### PR TITLE
WIP: Field: added method to load image files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ new: `ms = ms.filter('gamma > 2')`
 
 **Other improvements and new features**
 * Overload of the `~` (invert) operator on `postpic.MultiSpecies`. If `ms` is a MultiSpecies object with filtered particles (created by the use of `compress` or `filter`), then `~ms` inverts the selection of particles.
-* `postpic.Field` has methods `.loadfrom`, `.saveto` and `.export`. `.saveto` saves the complete Field object as a ` .npz` file. Use `.loadfrom` to load a Field object from file. `.export` is able to write `.csv` files and `.vtk` files in addition.
+* `postpic.Field` has methods `.loadfrom` and `.saveto`. These can be used to save a Field to a ` .npz` file for later use. Use `.loadfrom` to load a Field object from such a file. All attributes of the Field are restored.
+* `postpic.Field` has methods `.export` and `.import`. These are used to export fields to and import fields from foreign file formats such as `.csv`, `.vtk`, `.png`, `.tif`, `.jpg`. It is not guaranteed to get all attributes back after `.export`ing and than `.import`ing a Field. Some formats are not available for both methods.
 * `postpic` has a new function `time_profile_at_plane` that 'measures' the temporal profile of a pulse while passing through a plane
 * `postpic` has a new function `unstagger_fields` that will take a set of staggered fields and returns the fields after removing the stagger
 * `postpic` has a new function `export_vector_vtk` that takes up to three fields and exports them as a vector field in the `.vtk` format

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -447,6 +447,11 @@ class Field(NDArrayOperatorsMixin):
     def loadfrom(cls, filename):
         return io.load_field(filename)
 
+    @classmethod
+    @helper.append_doc_of(io.import_field)
+    def importfrom(cls, filename, **kwargs):
+        return io.import_field(filename, **kwargs)
+
     def __init__(self, matrix, name='', unit='', **kwargs):
         if 'xedges' in kwargs or 'axes' in kwargs:
             # Some axes have been passed, let length-1-dimensions alone

--- a/postpic/io/__init__.py
+++ b/postpic/io/__init__.py
@@ -24,7 +24,7 @@ The postpic.io module provides free functions for importing and exporting data.
 from .csv import _export_field_csv, _import_field_csv
 from .npy import _export_field_npy, _import_field_npy
 from .vtk import export_scalar_vtk, export_vector_vtk, export_scalars_vtk
-from .image import _import_field_image, _import_field_image_extensions
+from .image import _import_field_image
 
 __all__ = ['export_field', 'load_field',
            'export_scalar_vtk', 'export_scalars_vtk', 'export_vector_vtk']
@@ -43,17 +43,18 @@ def load_field(filename):
 def import_field(filename, **kwargs):
     '''
     Construct a new field object from foreign data. Currently, the following file
-    formats are supported:
-    *.png
-    *.tif
+    formats are supported explicitly:
     *.csv
+    *.png
+
+    All other files will be opened using Pillow.
     '''
     if filename.lower().endswith('csv'):
         return _import_field_csv(filename, **kwargs)
-    elif any(filename.lower().endswith(ext) for ext in _import_field_image_extensions):
-        return _import_field_image(filename, **kwargs)
     else:
-        raise ValueError('File format of filename {0} not recognized.'.format(filename))
+        # assume anything else, this will open png files with pypng and all other files
+        # with pillow
+        return _import_field_image(filename, **kwargs)
 
 
 def export_field(filename, field, **kwargs):

--- a/postpic/io/__init__.py
+++ b/postpic/io/__init__.py
@@ -52,6 +52,8 @@ def import_field(filename, **kwargs):
         return _import_field_csv(filename, **kwargs)
     elif any(filename.lower().endswith(ext) for ext in _import_field_image_extensions):
         return _import_field_image(filename, **kwargs)
+    else:
+        raise ValueError('File format of filename {0} not recognized.'.format(filename))
 
 
 def export_field(filename, field, **kwargs):

--- a/postpic/io/__init__.py
+++ b/postpic/io/__init__.py
@@ -21,9 +21,10 @@
 The postpic.io module provides free functions for importing and exporting data.
 '''
 
-from .csv import _export_field_csv
+from .csv import _export_field_csv, _import_field_csv
 from .npy import _export_field_npy, _import_field_npy
 from .vtk import export_scalar_vtk, export_vector_vtk, export_scalars_vtk
+from .image import _import_field_image, _import_field_image_extensions
 
 __all__ = ['export_field', 'load_field',
            'export_scalar_vtk', 'export_scalars_vtk', 'export_vector_vtk']
@@ -31,13 +32,26 @@ __all__ = ['export_field', 'load_field',
 
 def load_field(filename):
     '''
-    construct a new field object from file. currently, the following file
-    formats are supported:
-    *.npz
+    Load a field object previously stored using the `saveto` method. These are .npz files
+    with a specific metadata layout.
     '''
-    if not filename.endswith('npz'):
+    if not filename.lower().endswith('npz'):
         raise ValueError('File format of filename {0} not recognized.'.format(filename))
     return _import_field_npy(filename)
+
+
+def import_field(filename, **kwargs):
+    '''
+    Construct a new field object from foreign data. Currently, the following file
+    formats are supported:
+    *.png
+    *.tif
+    *.csv
+    '''
+    if filename.lower().endswith('csv'):
+        return _import_field_csv(filename, **kwargs)
+    elif any(filename.lower().endswith(ext) for ext in _import_field_image_extensions):
+        return _import_field_image(filename, **kwargs)
 
 
 def export_field(filename, field, **kwargs):
@@ -51,11 +65,11 @@ def export_field(filename, field, **kwargs):
     .vtk:
         vtk export to paraview
     '''
-    if filename.endswith('npz'):
+    if filename.lower().endswith('npz'):
         _export_field_npy(filename, field, **kwargs)
-    elif filename.endswith('csv'):
+    elif filename.lower().endswith('csv'):
         _export_field_csv(filename, field, **kwargs)
-    elif filename.endswith('vtk'):
+    elif filename.lower().endswith('vtk'):
         export_scalar_vtk(filename, field, **kwargs)
     else:
         raise ValueError('File format of filename {0} not recognized.'.format(filename))

--- a/postpic/io/csv.py
+++ b/postpic/io/csv.py
@@ -21,6 +21,8 @@
 The postpic.io module provides free functions for importing and exporting data.
 '''
 
+import os.path as osp
+
 import numpy as np
 
 from .common import _header_string
@@ -36,3 +38,24 @@ def _export_field_csv(filename, field):
     header += 'Data extent: {}\n'.format(field.extent)
     np.savetxt(filename, data, header=header)
     return
+
+
+def _import_field_csv(filename, delimiter=','):
+    '''
+    reads a .csv file using numpy.genfromtxt.
+
+    Args:
+        filename (str): Path and filename to the file to open
+
+    Returns:
+        numpy.array: the image data as numpy array converted to float64
+
+    Author: Stephan Kuschel, 2015-2016, Alexander Blinne 2017
+    '''
+    from ..datahandling import Field, Axis
+
+    ret = np.genfromtxt(filename, delimiter=delimiter)
+    axes = [Axis(name=name, unit='px', grid=np.linspace(0, ret.shape[i]-1, ret.shape[i]))
+            for i, name in enumerate('xy')]
+    basename = osp.basename(filename)
+    return Field(ret, name=basename, unit='?', axes=axes)

--- a/postpic/io/image.py
+++ b/postpic/io/image.py
@@ -1,0 +1,91 @@
+#
+# This file is part of postpic.
+#
+# postpic is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# postpic is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with postpic. If not, see <http://www.gnu.org/licenses/>.
+#
+# Alexander Blinne, 2017
+# Stephan Kuschel, 2017
+'''
+The postpic.io subpackage provides free functions for importing and exporting data.
+'''
+
+import os.path as osp
+
+import numpy as np
+
+_import_field_image_extensions = "png tif tiff jpg jpeg gif ".split()
+
+
+def _import_field_image(filename):
+    '''
+
+    '''
+    from ..datahandling import Field, Axis
+    if filename.lower().endswith('png'):
+        data = _readpng(filename)
+    else:
+        data = _read_image_pil(filename)
+
+    # image data are usually in y-major order, but postpic Fields assume x-major order
+    # and rows are stored from top to bottom while y axes coordinate grows from bottom to top
+    data = data.T[:, ::-1]
+
+    axes = [Axis(name=name, unit='px', grid=np.linspace(0, data.shape[i]-1, data.shape[i]))
+            for i, name in enumerate('xy')]
+    basename = osp.basename(filename)
+    return Field(data, unit='counts', name=basename, axes=axes)
+
+
+def _readpng(filename):
+    '''
+    Reads a png file and returns appropriate count vales, even if a bit depth
+    other than 8 or 16 is used. An example this might be needed is having a
+    12-bit png recorded from a 12-bit camera using LabViews IMAQ toolset.
+    In this case the PIL (python image library) fails to retrieve the
+    original count values.
+    Copied from https://gist.github.com/skuschel/87960f78c7a4a42eb042
+
+    Args:
+        filename (str): Path and filename to the file to open
+
+    kwargs:
+        hotpixelremove (bool): Removes hotpixels if True. (Default: True)
+
+    Returns:
+        numpy.array: the png data as numpy array converted to float64
+
+    Author: Stephan Kuschel, 2015-2016
+    '''
+    import png
+    r = png.Reader(filename)
+    ret = np.vstack(map(np.uint16, r.asDirect()[2]))
+    return np.float64(ret)
+
+
+def _read_image_pil(filename):
+    '''
+    reads an image file using PIL.Image.open.
+
+    Args:
+        filename (str): Path and filename to the file to open
+
+    Returns:
+        numpy.array: the image data as numpy array converted to float64
+
+    Author: Stephan Kuschel, 2015-2016
+    '''
+    from PIL import Image
+    im = Image.open(filename)
+    data = np.array(im, dtype=np.float64)
+    return data

--- a/postpic/io/image.py
+++ b/postpic/io/image.py
@@ -25,7 +25,7 @@ import os.path as osp
 import numpy as np
 
 
-def _import_field_image(filename):
+def _import_field_image(filename, hotpixelremove=False):
     '''
 
     '''
@@ -34,6 +34,15 @@ def _import_field_image(filename):
         data = _readpng(filename)
     else:
         data = _read_image_pil(filename)
+
+    if hotpixelremove:
+        import scipy.ndimage
+        if data.ndim == 3 and data.shape[2] < 5:
+            # assume multichannel image file like rgb or rgba
+            for i in range(data.shape[2]):
+                data[..., i] = scipy.ndimage.morphology.grey_opening(data[..., i], size=(3, 3))
+            else:
+                data = scipy.ndimage.morphology.grey_opening(data, size=(3, 3))
 
     # image data are usually in y-major order, but postpic Fields assume x-major order
     # and rows are stored from top to bottom while y axes coordinate grows from bottom to top

--- a/postpic/io/image.py
+++ b/postpic/io/image.py
@@ -24,7 +24,7 @@ import os.path as osp
 
 import numpy as np
 
-_import_field_image_extensions = "png tif tiff jpg jpeg gif ".split()
+_import_field_image_extensions = "png tif tiff jpg jpeg gif bmp".split()
 
 
 def _import_field_image(filename):

--- a/postpic/io/image.py
+++ b/postpic/io/image.py
@@ -24,8 +24,6 @@ import os.path as osp
 
 import numpy as np
 
-_import_field_image_extensions = "png tif tiff jpg jpeg gif bmp".split()
-
 
 def _import_field_image(filename):
     '''
@@ -71,9 +69,14 @@ def _readpng(filename):
 
     Author: Stephan Kuschel, 2015-2016
     '''
-    import png
-    r = png.Reader(filename)
-    ret = np.vstack(map(np.uint16, r.asDirect()[2]))
+    import png  # pypng
+    import scipy.misc as sm
+    import numpy as np
+    meta = png.Reader(filename)
+    meta.preamble()
+    significant_bits = ord(meta.sbit)
+    ret = sm.imread(filename)
+    ret >>= 16 - significant_bits
     return np.float64(ret)
 
 

--- a/postpic/io/image.py
+++ b/postpic/io/image.py
@@ -39,7 +39,7 @@ def _import_field_image(filename):
 
     # image data are usually in y-major order, but postpic Fields assume x-major order
     # and rows are stored from top to bottom while y axes coordinate grows from bottom to top
-    data = data.T[:, ::-1, ...]
+    data = np.moveaxis(data, 0, 1)[:, ::-1, ...]
 
     axes = []
     for i, (name, axlen) in enumerate(zip(['x', 'y', 'channel'], data.shape)):

--- a/postpic/io/image.py
+++ b/postpic/io/image.py
@@ -39,10 +39,14 @@ def _import_field_image(filename):
 
     # image data are usually in y-major order, but postpic Fields assume x-major order
     # and rows are stored from top to bottom while y axes coordinate grows from bottom to top
-    data = data.T[:, ::-1]
+    data = data.T[:, ::-1, ...]
 
-    axes = [Axis(name=name, unit='px', grid=np.linspace(0, data.shape[i]-1, data.shape[i]))
-            for i, name in enumerate('xy')]
+    axes = []
+    for i, (name, axlen) in enumerate(zip(['x', 'y', 'channel'], data.shape)):
+        ax = Axis(name=name, unit='px' if i < 2 else '',
+                  grid=np.linspace(0, axlen-1, axlen))
+        axes.append(ax)
+
     basename = osp.basename(filename)
     return Field(data, unit='counts', name=basename, axes=axes)
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ setup(name='postpic',
                         'cython>=0.18', 'functools32;python_version<"3.0"'],
       extras_require = {
         'h5 reader for openPMD support':  ['h5py'],
-        'sdf support for EPOCH reader':  ['sdf']},
+        'sdf support for EPOCH reader':  ['sdf'],
+        'PyPNG read png files': ['pypng'],
+        'Pillow to read other image files': ['pillow']},
       keywords = ['PIC', 'particle-in-cell', 'plasma', 'physics', 'plasma physics',
                   'laser', 'laser plasma', 'particle acceleration'],
       classifiers=[


### PR DESCRIPTION
Changed the io methods to have the following meaning:

* `postpic.Field` has methods `.loadfrom` and `.saveto`. These can be used to save a Field to a ` .npz` file for later use. Use `.loadfrom` to load a Field object from such a file. All attributes of the Field are restored.
* `postpic.Field` has methods `.export` and `.import`. These are used to export fields to and import fields from foreign file formats such as `.csv`, `.vtk`, `.png`, `.tif`, `.jpg`. It is not guaranteed to get all attributes back after `.export`ing and than `.import`ing a Field. Some formats are not available for both methods.