### PR TITLE
WIP: Allow reversed axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ new: `ms = ms.filter('gamma > 2')`
 * `postpic` has a new function `export_scalars_vtk` that takes up to four fields and exports them as multiple scalar fields on the same grid in the `.vtk` format
 * `postpic.Field` works now with all numpy ufuncs, also with `ufunc.reduce`, `ufunc.outer`, `ufunc.accumulate` and `ufunc.at`
 * `postpic.Field` now supports broadcasting like numpy arrays, for binary operators as well as binary ufunc operations
-* `postpic.Field` has methods `.swapaxes`, `.transpose` and property `.T` compatible to numpy.ndarray
+* `postpic.Field` has methods `.swapaxes`, `.transpose` and properties `.T` and `ndim` compatible to numpy.ndarray
 * `postpic.Field` has methods `all`, `any`, `max`, `min`, `prod`, `sum`, `ptp`, `std`, `var`, `mean`, `clip` compatible to numpy.ndarray
 * `postpic.Field` has a new method `map_axis_grid` for transforming the coordinates only along one axis which is simpler than `map_coordinates`, but also takes care of the Jacobian
 * `postpic.Field` has a new method `autocutout` used to slice away close-to-zero regions from the borders
@@ -32,6 +32,7 @@ new: `ms = ms.filter('gamma > 2')`
 * `postpic.Field` has a new method `adjust_stagger_to` to adjust the grid origin to match the grid origin of another field
 * `postpic.Field` has a new method `phase` to get the unwrapped phase of the field
 * `postpic.Field` has a new method `derivative` to calculate the derivative of a field
+* `postpic.Field` has new methods `flip` and `rot90` similar to `np.flip()` and `np.rot90()`
 * `postpic.Field.topolar` has new defaults for extent and shape
 * `postpic.Field.integrate` now uses the simpson method by default
 * New module `postpic.experimental` to contain experimental algorithms for your reference. These algorithms are not meant to be useable as-is, but may serve as recipes to write your own algorithms.

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -139,27 +139,31 @@ class Axis(object):
         self.name = name
         self.unit = unit
 
-        self._grid_node = kwargs.get('grid_node', None)
+        self._grid_node = kwargs.pop('grid_node', None)
 
         if self._grid_node is not None:
             self._grid_node = np.array(self._grid_node)
             if self._grid_node.ndim != 1:
                 raise ValueError("Passed array grid_node has ndim != 1.")
 
-        self._grid = kwargs.get('grid', None)
+        self._grid = kwargs.pop('grid', None)
 
         if self._grid is not None:
             self._grid = np.array(self._grid)
             if self._grid.ndim != 1:
                 raise ValueError("Passed array grid has ndim != 1.")
 
-        self._extent = kwargs.get('extent', None)
+        self._extent = kwargs.pop('extent', None)
 
         if self._extent is not None:
             if not isinstance(self._extent, collections.Iterable) or len(self._extent) != 2:
                 raise ValueError("Passed extent is not an iterable of length 2")
 
-        self._n = kwargs.get('n', None)
+        self._n = kwargs.pop('n', None)
+
+        # kwargs must be exhausted now
+        if len(kwargs) > 0:
+            raise TypeError('got an unexpcted keyword argument "{}"'.format(kwargs))
 
         if self._grid_node is None:
             if self._grid is None:

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -384,12 +384,12 @@ class Axis(object):
         a slice containing floats or integers or a float or an integer
         """
         sl = self._normalize_slice(key)
-        if sl.step is not None:
-            raise ValueError("Slices with step!=None not supported")
+        if not (sl.step is None or np.abs(sl.step) == 1):
+            raise ValueError("slice.step must be 1, -1 or None (but is {})".format(sl.step))
         grid = self.grid[sl]
         stop = sl.stop
         if stop is not None and stop > 0:
-            stop += 1
+            stop += -1 if sl.step == -1 else 1
         sln = slice(sl.start if sl.start else None, stop)
         grid_node = self.grid_node[sln]
         ax = type(self)(self.name, self.unit, grid=grid, grid_node=grid_node)
@@ -893,6 +893,10 @@ class Field(NDArrayOperatorsMixin):
         if np.prod(self.shape) == 0:  # handels everything without data
             ret = -1
         return ret
+
+    @property
+    def ndim(self):
+        return self.matrix.ndim
 
     @property
     def extent(self):
@@ -1491,6 +1495,39 @@ class Field(NDArrayOperatorsMixin):
         ax = ret.axes[axis].reversed()
         ret.axes[axis] = ax
         return ret
+
+    def rot90(self, k=1, axes=(0, 1)):
+        """
+        Rotates the field by 90 degrees, `k` times. Rotates the field in the plane given by `axes`.
+        """
+        # copied most of the code from
+        # https://github.com/numpy/numpy/blob/v1.15.1/numpy/lib/function_base.py#L62-L145
+        axes = tuple(axes)
+        if len(axes) != 2:
+            raise ValueError("len(axes) must be 2.")
+        if axes[0] == axes[1]:
+            raise ValueError("Axes must be different.")
+        if (axes[0] >= self.ndim or axes[0] < -self.ndim or
+                axes[1] >= self.ndim or axes[1] < -self.ndim):
+            raise ValueError("Axes={} out of range for array of ndim={}."
+                             .format(axes, self.ndim))
+
+        k %= 4
+
+        if k == 0:
+            return copy.copy(self)
+        if k == 2:
+            return self.flip(axes[0]).flip(axes[1])
+
+        axes_list = np.arange(0, self.ndim)
+        (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]],
+                                                    axes_list[axes[0]])
+
+        if k == 1:
+            return self.flip(axes[1]).transpose(axes_list)
+        else:
+            # k == 3
+            return self.transpose(axes_list).flip(axes[1])
 
     def ensure_positive_axes(self):
         '''

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1490,6 +1490,17 @@ class Field(NDArrayOperatorsMixin):
         ret.axes[axis] = ax
         return ret
 
+    def ensure_positive_axes(self):
+        '''
+        ensures, that all axis are going from smaller to greater numbers,
+        i.e. none of the axis is reversed.
+        '''
+        ret = self
+        for i, ax in enumerate(self.axes):
+            if ax.isreversed():
+                ret = ret.flip(i)
+        return ret
+
     def _integrate_constant(self, axes):
         '''
         Integrate by assuming constant value across each grid cell, even for uneven grids.

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -371,6 +371,13 @@ class Axis(object):
                 index = self._find_nearest_index(index)
             return slice(index, index+1)
 
+    def reversed(self):
+        '''
+        returns an reversed Axis object
+        '''
+        ax = type(self)(self.name, self.unit, grid_node=self.grid_node[::-1], grid=self.grid[::-1])
+        return ax
+
     def __getitem__(self, key):
         """
         Returns an Axis which consists of a sub-part of this object defined by

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1481,9 +1481,11 @@ class Field(NDArrayOperatorsMixin):
 
     def flip(self, axis):
         '''
-        identical to `numpy.flip`.
+        functionality of `numpy.flip`.
 
-        TODO: make `numpy.flip(field)` work!
+        `field.flip(0)` returns a `postpic.Field` object with the
+        specified axis flipped. `np.flip(field)` returns only
+        the `numpy.ndarray` and the axis information is lost.
         '''
         ret = self.replace_data(np.flip(self, axis))
         ax = ret.axes[axis].reversed()

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1989,8 +1989,10 @@ class Field(NDArrayOperatorsMixin):
         self.export(filename)
 
     def __str__(self):
-        s = '<Field "{:}" {:}>'
+        s = '<postpic.Field "{:}" {:}>'
         return s.format(self.name, self.shape)
+
+    __repr__ = __str__
 
     def _extent_to_slices(self, extent):
         if not self.dimensions * 2 == len(extent):

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -261,7 +261,7 @@ class Axis(object):
     def spacing(self):
         if not self.islinear():
             raise TypeError('Grid must be linear to calculate gridspacing')
-        return self.grid_node[1] - self.grid_node[0]
+        return np.abs(self.grid_node[1] - self.grid_node[0])
 
     @property
     def extent(self):
@@ -269,7 +269,7 @@ class Axis(object):
 
     @property
     def physical_length(self):
-        return self._extent[1] - self._extent[0]
+        return np.abs(self._extent[1] - self._extent[0])
 
     @property
     def label(self):

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1479,6 +1479,17 @@ class Field(NDArrayOperatorsMixin):
             return out
         return self.replace_data(o)
 
+    def flip(self, axis):
+        '''
+        identical to `numpy.flip`.
+
+        TODO: make `numpy.flip(field)` work!
+        '''
+        ret = self.replace_data(np.flip(self, axis))
+        ax = ret.axes[axis].reversed()
+        ret.axes[axis] = ax
+        return ret
+
     def _integrate_constant(self, axes):
         '''
         Integrate by assuming constant value across each grid cell, even for uneven grids.

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -270,19 +270,6 @@ def is_non_integer_real_number(x):
     return isinstance(x, numbers.Real) and not isinstance(x, numbers.Integral)
 
 
-def find_nearest_index(array, value):
-    """
-    Gives the index i of the value array[i] which is closest to value.
-    Assumes that the array is sorted.
-    """
-    idx = np.searchsorted(array, value, side="left")
-    if idx > 0 and (idx == len(array) or
-                    np.fabs(value - array[idx-1]) < np.fabs(value - array[idx])):
-                        return idx-1
-    else:
-        return idx
-
-
 def max_frac_bounds(array, fraction):
     """
     For a 1d Array `array` this function gives indices `a`, `b` such that all values

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -92,6 +92,10 @@ class TestAxis(unittest.TestCase):
         ax2 = dh.Axis(grid = [5.5, 6.0], extent = [1, 11])
         self.assertNotEqual(ax1, ax2)
 
+    def test_init(self):
+        with self.assertRaises(TypeError):
+            dh.Axis(extent=(0,1), n=99, unknownarg=0)
+
 
 class TestField(unittest.TestCase):
 

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -612,6 +612,8 @@ class TestField(unittest.TestCase):
         self.assertEqual(b.axes, self.f1d.axes + self.f2d.axes)
         self.assertAllEqual(b.matrix, np.multiply.outer(self.f1d.matrix, self.f2d.matrix))
 
+    @unittest.skipIf(pr.parse_version(np.__version__) < pr.parse_version("1.12"),
+                 "This behaviour is not supported for numpy older than 1.12")
     def test_flip(self):
         f2df = self.f2d.flip(axis=-1)
         self.assertAllEqual(f2df.extent, [0,1,1,0])

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -100,8 +100,9 @@ class TestAxis(unittest.TestCase):
         ax = dh.Axis(extent=[-1,1], n=n)
         axri = dh.Axis(extent=[1,-1], n=n)
         self.assertEqual(ax.value_to_index(0), axri.value_to_index(0))
-        #self.assertTrue(ax, axrr)
-        #self.assertTrue(axri, axr)
+        axrr = ax.reversed().reversed()
+        self.assertEqual(ax, axrr)
+        self.assertTrue(axri, ax.reversed())
 
     def test_reversed_odd(self):
         self.test_reversed(n=101)

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -149,7 +149,7 @@ class TestField(unittest.TestCase):
 
     def checkFieldConsistancy(self, field):
         '''
-        general consistancy check. must never fail.
+        general consistency check. must never fail.
         '''
         self.assertEqual(field.dimensions, len(field.axes))
         for i in range(len(field.axes)):
@@ -612,6 +612,11 @@ class TestField(unittest.TestCase):
         self.assertEqual(b.axes, self.f1d.axes + self.f2d.axes)
         self.assertAllEqual(b.matrix, np.multiply.outer(self.f1d.matrix, self.f2d.matrix))
 
+    def test_flip(self):
+        f2df = self.f2d.flip(axis=-1)
+        self.assertAllEqual(f2df.extent, [0,1,1,0])
+        self.assertAllEqual(f2df.flip(axis=-1), self.f2d)
+        self.assertAllEqual(self.f2d, self.f2d.flip(0).flip(1).flip(0).flip(1))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -96,6 +96,33 @@ class TestAxis(unittest.TestCase):
         with self.assertRaises(TypeError):
             dh.Axis(extent=(0,1), n=99, unknownarg=0)
 
+    def test_reversed(self, n=100):
+        ax = dh.Axis(extent=[-1,1], n=n)
+        axri = dh.Axis(extent=[1,-1], n=n)
+        self.assertEqual(ax.value_to_index(0), axri.value_to_index(0))
+        #self.assertTrue(ax, axrr)
+        #self.assertTrue(axri, axr)
+
+    def test_reversed_odd(self):
+        self.test_reversed(n=101)
+
+    def test_extent_to_slice_even(self, n=100):
+        ax = dh.Axis(extent=[-1,1], n=n)
+        axr = dh.Axis(extent=[1,-1], n=n)
+        self.assertEqual(ax._extent_to_slice((-1,0)), slice(0, 50))
+        self.assertEqual(ax._extent_to_slice((0,-1)), slice(50, 0, -1))
+        self.assertEqual(axr._extent_to_slice((-1,0)), slice(100, 50, -1))
+        self.assertEqual(axr._extent_to_slice((0,-1)), slice(50, 100))
+
+        self.assertEqual(ax._extent_to_slice((0,1)), slice(50, 100))
+        self.assertEqual(ax._extent_to_slice((1,0)), slice(100, 50, -1))
+        self.assertEqual(axr._extent_to_slice((0,1)), slice(50, 0, -1))
+        self.assertEqual(axr._extent_to_slice((1,0)), slice(0, 50))
+
+        self.assertEqual(ax._extent_to_slice((-1,1)), slice(0, 100))
+        self.assertEqual(ax._extent_to_slice((1,-1)), slice(100, 0, -1))
+        self.assertEqual(axr._extent_to_slice((-1,1)), slice(100, 0, -1))
+        self.assertEqual(axr._extent_to_slice((1,-1)), slice(0, 100))
 
 class TestField(unittest.TestCase):
 

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -619,6 +619,33 @@ class TestField(unittest.TestCase):
         self.assertAllEqual(f2df.extent, [0,1,1,0])
         self.assertAllEqual(f2df.flip(axis=-1), self.f2d)
         self.assertAllEqual(self.f2d, self.f2d.flip(0).flip(1).flip(0).flip(1))
+        self.assertAllEqual(self.f2d, self.f2d.flip(0).flip(1).flip(1).flip(0))
+
+    @unittest.skipIf(pr.parse_version(np.__version__) < pr.parse_version("1.12"),
+                 "This behaviour is not supported for numpy older than 1.12")
+    def test_rot90(self):
+        f2dr = self.f2d.rot90().rot90().rot90().rot90()
+        self.assertAllEqual(self.f2d, f2dr)
+        self.assertAllEqual(self.f2d.extent, f2dr.extent)
+        f2dr = self.f2d.rot90().rot90(k=2).rot90()
+        self.assertAllEqual(self.f2d, f2dr)
+        self.assertAllEqual(self.f2d.extent, f2dr.extent)
+        f2dr = self.f2d.rot90(k=3).rot90()
+        self.assertAllEqual(self.f2d, f2dr)
+        self.assertAllEqual(self.f2d.extent, f2dr.extent)
+        f2dr = self.f2d.rot90(k=4)
+        self.assertAllEqual(self.f2d, f2dr)
+        self.assertAllEqual(self.f2d.extent, f2dr.extent)
+
+    def test_rot90_2(self):
+        f2dr = np.rot90(self.f2d, k=4)
+        self.assertAllEqual(self.f2d, f2dr)
+        f2dr = np.rot90(self.f2d, k=3)
+        f2drot = self.f2d.rot90(k=3)
+        self.assertAllEqual(f2drot, f2dr)
+        # this would fail, as f2drot is a np.ndarray
+        # self.assertAllEqual(f2drot.extent, f2dr.extent)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR changes the Axis and Field object such, that reversed axis, i.e. decreasing values on the axis, are allowed. It also implements the `flip` function. 

This PR competes with #173 and some features of #173 still have to be merged. 