### PR TITLE
Field._map_coordinates: make shallow copy of newaxes list

### DIFF
--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1134,7 +1134,7 @@ class Field(NDArrayOperatorsMixin):
 
         # Start a new Field object by inserting the new axes
         ret = copy.copy(self)
-        ret.axes = newaxes
+        ret.axes = list(newaxes)
         shape = [len(ax) for ax in newaxes]
 
         # Calculate the output grid


### PR DESCRIPTION
this avoids a situation, where the user has a direct reference to a Fields axes list.