### PR TITLE
Field: added new integrate method 'fast'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ new: `ms = ms.filter('gamma > 2')`
 * `postpic.Field` has new methods `flip` and `rot90` similar to `np.flip()` and `np.rot90()`
 * `postpic.Field.topolar` has new defaults for extent and shape
 * `postpic.Field.integrate` now uses the simpson method by default
+* `postpic.Field.integrate` now has a new 'fast' method that uses numexpr, suitable for large datasets
 * New module `postpic.experimental` to contain experimental algorithms for your reference. These algorithms are not meant to be useable as-is, but may serve as recipes to write your own algorithms.
 * k-space reconstruction from EPOCH dumps has greatly improved accuracy due to a new algorithm correctly incorporating the frequency response of the implicit linear interpolation performed by EPOCH's half-steps
 * `plotter_matplotlib.plotField` allows to override `aspect` option to `imshow`

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -482,11 +482,23 @@ class TestField(unittest.TestCase):
 
         self.assertTrue(np.isclose(a, b))
 
+        print('start f1d.integrate')
+        a = self.f1d.integrate(method='fast')
+
+        print('type(a.matrix)', type(a.matrix))
+        self.assertTrue(np.isclose(a, b))
+
         b = self.f2d_fine.integrate(method=scipy.integrate.simps)
         c = self.f2d_fine.integrate(method=scipy.integrate.trapz)
 
         self.assertTrue(np.isclose(b, 0))
         self.assertTrue(np.isclose(c, 0))
+
+    def test_integrate_fast(self):
+        for axes in [0, 1, 2, (0,1), (0,2), (0,1,2)]:
+            a = self.f3d.integrate(axes, method='constant')
+            b = self.f3d.integrate(axes, method='fast')
+            np.testing.assert_allclose(a, b)
 
     def test_derivative(self):
         d = self.f1d.derivative(0, staggered=True)


### PR DESCRIPTION
Changes:

* `postpic.Field.integrate` now has a new 'fast' method that uses numexpr, suitable for large datasets