### PR TITLE
Field: added method evaluate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ In case you find particle scalar that you use regularly which is not in the list
 * `Field.fft` function for fft optimized with pyfftw (thanks to @Ablinne).
 * `Field.__getitem__` to slice a Field object. If integers are provided, it will interpret them as gridpoints. If float are provided they are interpreted as the physical region of the data and slice along the corresponding axis positions (thanks to @Ablinne).
 * `Field` class has been massively impoved (thanks to @Ablinne): The operator overloading is now properly implemented and thanks to `__array__` method, it can be interpreted by numpy as an ndarray whenever necessary.
-* List of new functions of the `Field` class (thanks to @Ablinne): `meshgrid`, `conj`, `replace_data`, `pad`, `transform`, `squeeze`, `integrate`, `fft`, `shift_grid_by`, `__getitem__`, `__setitem__`.
+* List of new functions of the `Field` class (thanks to @Ablinne): `meshgrid`, `conj`, `replace_data`, `pad`, `transform`, `squeeze`, `integrate`, `fft`, `shift_grid_by`, `__getitem__`, `__setitem__`, `evaluate`.
 * List of new properties of the `Field` class (thanks to @Ablinne): `matrix`, `real`, `imag`, `angle`.
 * Many performance optimizations using pyfftw library (optional) or numexpr (now required by postpic) or by avoiding in memory data copying.
 * Lots of fixes


### PR DESCRIPTION
This introduces a new method `evaluate()` for `Field`, which evaluates the expression `ex` using `NumExpr` and returns a field containing the result.
        This copies all metadata from `self` and just replaces the matrix.

This function is basically syntactic sugar simplifying

        field.replace_data(ne.evaluate(expr))

to

        field.evaluate(expr)

This method replicates some logic from NumExpr.necompiler.getArguments(), seems
        there is no way around it.