### PR TITLE
Implement Field.copy() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## current master
 
+* New convenience method `Field.copy`
+
 ## v0.4
 2019-01-14
 

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -627,6 +627,35 @@ class Field(NDArrayOperatorsMixin):
             ret.__dict__[k] = copy.copy(self.__dict__[k])
         return ret
 
+    def __deepcopy__(self, memo=None):
+        '''
+        returns a deep copy of the object.
+        This method is called by `copy.deepcopy(obj)`.
+
+        Although Field objects are mostly immutable, they have a __setitem__, which is useful
+        in some cases. Sometimes, one needs an easy way to copy a Field before using __setitem__.
+        This function copies the underlying data to make sure that no modifications applied to
+        the copy affect the source.
+
+        As the contents of `axes` should be strictly immutable, they don't need to be copied.
+        '''
+        ret = copy.copy(self)
+        ret.matrix = self.matrix.copy()
+        return ret
+
+    def copy(self, deep=True):
+        '''
+        Return a copy of the Field.
+
+        deep: return a deep copy ()
+
+        Similar to `numpy.ndarray.copy`.
+        '''
+        if deep:
+            return copy.deepcopy(self)
+        else:
+            return copy.copy(self)
+
     # Stuff related with compatibility to Numpy's ufuncs starts here.
     def _get_axes_ats_tao_binary_ufunc_broadcasting(self, other):
         """

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -162,6 +162,39 @@ class TestField(unittest.TestCase):
         for i in range(len(field.axes)):
             self.assertEqual(len(field.axes[i]), field.matrix.shape[i])
 
+    def test_copy(self):
+        c1d = self.f1d.copy(deep=False)
+        assert c1d.matrix is self.f1d.matrix
+
+        assert c1d.axes is not self.f1d.axes
+        assert c1d.axes == self.f1d.axes
+
+        assert c1d.axes_transform_state is not self.f1d.axes_transform_state
+        assert c1d.axes_transform_state == self.f1d.axes_transform_state
+
+        assert c1d.transformed_axes_origins is not self.f1d.transformed_axes_origins
+        assert c1d.transformed_axes_origins == self.f1d.transformed_axes_origins
+
+        assert c1d.infos is not self.f1d.infos
+        assert c1d.infos == self.f1d.infos
+
+        c1d = self.f1d.copy(deep=True)
+        assert c1d.matrix is not self.f1d.matrix
+        np.testing.assert_equal(c1d.matrix, self.f1d.matrix)
+
+        assert c1d.axes is not self.f1d.axes
+        assert c1d.axes == self.f1d.axes
+
+        assert c1d.axes_transform_state is not self.f1d.axes_transform_state
+        assert c1d.axes_transform_state == self.f1d.axes_transform_state
+
+        assert c1d.transformed_axes_origins is not self.f1d.transformed_axes_origins
+        assert c1d.transformed_axes_origins == self.f1d.transformed_axes_origins
+
+        assert c1d.infos is not self.f1d.infos
+        assert c1d.infos == self.f1d.infos
+
+
     def test_extent(self):
         self.assertListEqual(list(self.f0d.extent), [])
         self.assertListEqual(list(self.f1d.extent), [0, 1])


### PR DESCRIPTION
I sometimes need to copy fields deeply, e.g. when using `Field.__setitem__`. This would make it more convenient.