### PR TITLE
Use improved handling of phases in fft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * New convenience method `Field.copy`
 * Parallelized implementation of `Field.map_coordinates`
+* Reimplementation of `Field.fft`. This changes the phases of Fourier transforms in a way to make it more consistent. However, if your code depends on the phases, `Field.fft()` now has a parameter `old_behaviour` that can be used to switch back to the old behaviour.
 
 ## v0.4
 2019-01-14

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -2009,12 +2009,12 @@ class Field(NDArrayOperatorsMixin):
         ret = self.copy(deep=False)
 
         if exponential_signs == 'temporal':
-            ret.matrix = np.conjugate(ret.matrix)
+            ret = ret.conj()
 
         ret = ret._apply_linear_phase(output_origins)
 
         # Transforming...
-        fftfun = fft.ifftn if transform_state else fft.fftn
+        fftfun = {True: fft.ifftn, False: fft.fftn}[transform_state]
         ret.matrix = fftnorm * fftfun(ret.matrix, axes=axes, **my_fft_args)
 
         for i in axes:
@@ -2036,7 +2036,7 @@ class Field(NDArrayOperatorsMixin):
         ret = ret._apply_linear_phase(negative_input_origins, phi0=phi0)
 
         if exponential_signs == 'temporal':
-            ret.matrix = np.conjugate(ret.matrix)
+            ret = ret.conj()
 
         return ret
 

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1917,7 +1917,7 @@ class Field(NDArrayOperatorsMixin):
                 new_axes[i] += self.transformed_axes_origins[i] - new_axes[i][0]
         return new_axes
 
-    def fft(self, axes=None, exponential_signs='spatial', **kwargs):
+    def fft(self, axes=None, exponential_signs='spatial', old_behaviour=False, **kwargs):
         '''
         Performs Fourier transform on any number of axes.
 
@@ -1930,11 +1930,15 @@ class Field(NDArrayOperatorsMixin):
         Parameters
         ----------
 
-        exponential_signs:
+        exponential_signs: string
             configures the sign convention of the exponential.
 
             * exponential_signs == 'spatial':  fft using exp(-ikx), ifft using exp(ikx)
             * exponential_signs == 'temporal':  fft using exp(iwt), ifft using exp(-iwt)
+
+        old_behaviour: boolean
+            Do not remove the linear phase present in the fft of data that lie on a grid
+            that does not start at 0. Default is False.
 
         **kwargs:
             keyword-arguments are passed to the underlying fft implementation.
@@ -1970,6 +1974,11 @@ class Field(NDArrayOperatorsMixin):
         negative_input_origins = {i: -self.axes[i].grid[0] for i in axes}
         output_origins = {i: new_axes[i][0] for i in axes}
         phi0 = sum(input_origins[i] * output_origins[i] for i in axes)
+        if old_behaviour:
+            if transform_state is False:
+                negative_input_origins = {i: 0 for i in axes}
+            else:
+                output_origins = {i: 0 for i in axes}
 
         # Grid spacing
         dx = {i: self.axes[i].spacing for i in axes}

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -9,7 +9,7 @@ import numexpr as ne
 import copy
 import scipy.integrate
 import pkg_resources as pr
-
+import sys
 
 class TestAxis(unittest.TestCase):
 
@@ -330,16 +330,22 @@ class TestField(unittest.TestCase):
         spectrum_reference[65] = np.sqrt(2*np.pi)
         spectrum_reference[69] = 2*np.sqrt(2*np.pi)
 
-        x = np.linspace(0, 2*np.pi, 128, endpoint=False, dtype=np.complex128)
-        y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
+        x = np.linspace(0, 2*np.pi, 128, endpoint=False)
+        if sys.version_info.major == 3 and sys.version_info.minor < 5:
+            y = np.exp(1.j*x) + 2.*np.exp(5.j*x)
+        else:
+            y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
         y = dh.Field(y, axes=[dh.Axis(grid=x)])
         yf = y.fft()
 
         # this is passed already with the old code
         self.assertAllClose(spectrum_reference, yf, atol=1e-10)
 
-        x = np.linspace(0, 2*np.pi, 128, endpoint=False, dtype=np.complex128) + 3*np.pi/4
-        y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
+        x = np.linspace(0, 2*np.pi, 128, endpoint=False) + 3*np.pi/4
+        if sys.version_info.major == 3 and sys.version_info.minor < 5:
+            y = np.exp(1.j*x) + 2.*np.exp(5.j*x)
+        else:
+            y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
         y = dh.Field(y, axes=[dh.Axis(grid=x)])
         yf = y.fft()
 

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -330,7 +330,7 @@ class TestField(unittest.TestCase):
         spectrum_reference[65] = np.sqrt(2*np.pi)
         spectrum_reference[69] = 2*np.sqrt(2*np.pi)
 
-        x = np.linspace(0, 2*np.pi, 128, endpoint=False)
+        x = np.linspace(0, 2*np.pi, 128, endpoint=False, dtype=np.complex128)
         y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
         y = dh.Field(y, axes=[dh.Axis(grid=x)])
         yf = y.fft()
@@ -338,7 +338,7 @@ class TestField(unittest.TestCase):
         # this is passed already with the old code
         self.assertAllClose(spectrum_reference, yf, atol=1e-10)
 
-        x = np.linspace(0, 2*np.pi, 128, endpoint=False) + 3*np.pi/4
+        x = np.linspace(0, 2*np.pi, 128, endpoint=False, dtype=np.complex128) + 3*np.pi/4
         y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
         y = dh.Field(y, axes=[dh.Axis(grid=x)])
         yf = y.fft()

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -331,7 +331,7 @@ class TestField(unittest.TestCase):
         spectrum_reference[69] = 2*np.sqrt(2*np.pi)
 
         x = np.linspace(0, 2*np.pi, 128, endpoint=False)
-        y = ne.evaluate('exp(1j*x) + 2*exp(5j*x)')
+        y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
         y = dh.Field(y, axes=[dh.Axis(grid=x)])
         yf = y.fft()
 
@@ -339,7 +339,7 @@ class TestField(unittest.TestCase):
         self.assertAllClose(spectrum_reference, yf, atol=1e-10)
 
         x = np.linspace(0, 2*np.pi, 128, endpoint=False) + 3*np.pi/4
-        y = ne.evaluate('exp(1j*x) + 2*exp(5j*x)')
+        y = ne.evaluate('exp(1.j*x) + 2.*exp(5.j*x)')
         y = dh.Field(y, axes=[dh.Axis(grid=x)])
         yf = y.fft()
 


### PR DESCRIPTION
I'm working on a new implementation of the `Field.fft()` method that has 2 advantages over the current one:
1. Does not rely on slow, single threaded `fft.fftshift` and `fft.ifftshift` functions
2. Automatically removes linear phases that stem from having a grid, that does not have the 0-point exactly at the 0 index, like fft likes to have it. For both directions of the transformations
3. Handles both directions of the transform in a much more symmetric way

