### PR TITLE
Fix bug #215

### DIFF
--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -1056,27 +1056,16 @@ def _kspace_propagate_generator(kspace, dt, moving_window_vect=None,
     if move_window:
         if moving_window_vect is None:
             raise ValueError("Missing required argument moving_window_vect.")
-        exp_ikdx = linear_phase(kspace, moving_window_dict)
-        exp_ikdx_iwt = ne.evaluate('exp_iwt * exp_ikdx')
 
     while True:
-        if move_window:
-            # Apply the phase due the propagation via the dispersion relation omega
-            # and apply the linear phase due to the moving window
-            if use_numexpr_in_inner_loop:
-                kspace = kspace.replace_data(ne.evaluate('kspace * exp_ikdx_iwt'))
-            else:
-                kspace = kspace * exp_ikdx_iwt
-
-            for i in moving_window_dict.keys():
-                kspace.transformed_axes_origins[i] += moving_window_dict[i]
-
+        # Apply the phase due the propagation via the dispersion relation omega
+        if use_numexpr_in_inner_loop:
+            kspace = kspace.replace_data(ne.evaluate('kspace * exp_iwt'))
         else:
-            # Apply the phase due the propagation via the dispersion relation omega
-            if use_numexpr_in_inner_loop:
-                kspace = kspace.replace_data(ne.evaluate('kspace * exp_iwt'))
-            else:
-                kspace = kspace * exp_iwt
+            kspace = kspace * exp_iwt
+
+        for i in moving_window_dict.keys():
+            kspace.transformed_axes_origins[i] += moving_window_dict[i]
 
         if do_fft:
             yield kspace.fft()

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -1064,8 +1064,9 @@ def _kspace_propagate_generator(kspace, dt, moving_window_vect=None,
         else:
             kspace = kspace * exp_iwt
 
-        for i in moving_window_dict.keys():
-            kspace.transformed_axes_origins[i] += moving_window_dict[i]
+        if move_window:
+            for i in moving_window_dict.keys():
+                kspace.transformed_axes_origins[i] += moving_window_dict[i]
 
         if do_fft:
             yield kspace.fft()
@@ -1187,6 +1188,11 @@ def time_profile_at_plane(kspace_or_complex_field, axis='x', value=None, dir=1, 
         initial_dt = dir * (value-r) / PhysicalConstants.c
 
     kspace = kspace_propagate(kspace, initial_dt, **kwargs)
+
+    input_origin = kspace.axes[axis].grid[0]
+    output_origin = kspace._conjugate_grid(axis)[axis][0]
+    phi0 = input_origin * output_origin
+    kspace = kspace._apply_linear_phase({axis: output_origin}, phi0=-phi0)
 
     # setup a generator for the propagated kspaces
     kwargs['nsteps'] = len(complex_field.axes[axis])


### PR DESCRIPTION
Since the linear phase of the grid shift is now applied by the `fft()` method itself, it does not need to be applied by `_kspace_propagate_generator` in the case of a moving window. However, as `time_profile_at_plane` does not use `fft()` for the inverse transform, special handling is needed here.