### PR TITLE
use git sha as __version__ if nothing better is available

### DIFF
--- a/postpic/__init__.py
+++ b/postpic/__init__.py
@@ -75,4 +75,7 @@ __all__ += io.__all__
 
 __version__ = get_versions()['version']
 __git_version__ = get_versions()['full-revisionid']
+# work around if zip is downloaded from github and current version does not have a tag.
+if __version__ == '0+unknown':
+    __version__ = __git_version__
 del get_versions


### PR DESCRIPTION
workaround to fix #218

necessary if a zip is downloaded from github for a version without tag.