### PR TITLE
Fix travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ before_install:
   - ./miniconda.sh -b -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
   - conda update --yes conda;
+  - conda config --append channels anaconda
   - conda create -yn pyenv python=$TRAVIS_PYTHON_VERSION atlas numpy=$NUMPY_V scipy=$SCIPY_V matplotlib=$MATPLOTLIB_V nose cython=$CYTHON_V h5py numexpr sphinx pygments$PYGMENTS_V $EXTRAPACK
   - source activate pyenv
 


### PR DESCRIPTION
The anaconda channel must be explicitly added now. Probably caused by some conda update. 