### PR TITLE
Fix helper.jac_det for 1d case

### DIFF
--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1319,6 +1319,8 @@ class Field(NDArrayOperatorsMixin):
         jacobian_func: callable
             a callable that returns the jacobian of the transform. If this is
             not given, the jacobian is numerically approximated.
+            In a 1D to 1D transform this callable should return just the derivative of the
+            transform wrapped in a 1-element iterable.
 
         **kwargs:
             Keyword arguments captured by `helper.map_coordinates_parallel`:
@@ -1460,6 +1462,14 @@ class Field(NDArrayOperatorsMixin):
                 \int_V \mathop{\mathrm{d}x} \mathop{\mathrm{d}y} U(x,y) =
                 \int_{T^{-1}(V)} \mathop{\mathrm{d}r}\mathop{\mathrm{d}\theta}
                 \tilde{U}(r,\theta)\,.
+
+            In a 1D to 1D transform, please make sure that the transform function returns the
+            coordinates in a 1-element list, e.g.
+
+            >>> def T(r):
+            >>>    x = 2*r**2
+            >>>    return [x]
+
         '''
         return self._map_coordinates(newaxes, transform=transform, complex_mode=complex_mode,
                                      preserve_integral=preserve_integral,

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1344,6 +1344,12 @@ class Field(NDArrayOperatorsMixin):
                 return 1.0
 
         if preserve_integral:
+            if len(newaxes) != self.dimensions:
+                raise ValueError('Preserving the integral through preserve_integral=True is only'
+                                 'possible for transforms that have the same number of input and'
+                                 'output dimensions.'
+                                 'Please pass preserve_integral=False explicitly to allow such'
+                                 'transforms.')
             if jacobian_determinant_func is None:
                 if jacobian_func is None:
                     jacobian_func = helper.approx_jacobian(transform)

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -326,6 +326,10 @@ def jac_det(jacobian_func):
 
     det_fun = jac_det(polar2linear_jac)
     def = det_fun(theta, r)
+
+    In the case of a scalar function, this function expects jacobian_func to return
+    the derivative in a 1-element iterable. This behaviour is compatible to the output of
+    `np.gradient` and `approx_jacobian`.
     '''
     def fun(*coords):
         jac = jacobian_func(*coords)

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -386,7 +386,11 @@ def approx_jacobian(transform):
                                      'non-equidistant grid is not implemented for numpy < 1.13.')
             ravel_coords = [(r[-1]-r[0])/(len(r)-1) for r in ravel_coords]
 
-        shape = np.broadcast(*coords).shape
+        if len(coords) == 1:
+            # this specific case breaks np.broadcast in numpy 1.8.1 and older
+            shape = coords[0].shape
+        else:
+            shape = np.broadcast(*coords).shape
         mapped_coords = transform(*coords)
         mapped_coords = [broadcast_to(c, shape) for c in mapped_coords]
         jac = [np.gradient(c, *ravel_coords) for c in mapped_coords]

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -329,6 +329,8 @@ def jac_det(jacobian_func):
     '''
     def fun(*coords):
         jac = jacobian_func(*coords)
+        if len(jac) == 1:
+            return abs(jac[0])
         shape = np.broadcast(*coords).shape
         jacarray = np.asarray([[broadcast_to(a, shape) for a in row] for row in jac])
         jacarray = moveaxis(jacarray, [0, 1], [-2, -1])


### PR DESCRIPTION
Small fix for `helper.jac_det` for the 1D-case. This fixes problems when using `pp.Field.map_coordinates` for 1D transforms.