### PR TITLE
compatibility to new numpy scipy and numexpr versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -1742,7 +1742,7 @@ class Field(NDArrayOperatorsMixin):
     def _integrate_scipy(self, axes, method):
         ret = copy.copy(self)
         for axis in reversed(sorted(axes)):
-            ret._matrix = method(ret, ret.axes[axis].grid, axis=axis)
+            ret._matrix = method(ret, x=ret.axes[axis].grid, axis=axis)
             del ret.axes[axis]
             del ret.axes_transform_state[axis]
             del ret.transformed_axes_origins[axis]
@@ -1787,7 +1787,7 @@ class Field(NDArrayOperatorsMixin):
 
         return ret
 
-    def integrate(self, axes=None, method=scipy.integrate.simps):
+    def integrate(self, axes=None, method=scipy.integrate.simpson):
         '''
         Calculates the definite integral along the given axes.
 

--- a/postpic/datahandling.py
+++ b/postpic/datahandling.py
@@ -794,6 +794,7 @@ class Field(NDArrayOperatorsMixin):
                 ats = self.axes_transform_state[:]
                 tao = self.transformed_axes_origins[:]
                 reduceaxis = kwargs.get('axis', 0)
+                reduceaxis = range(len(axes)) if reduceaxis is None else reduceaxis
                 if not isinstance(reduceaxis, Iterable):
                     reduceaxis = (reduceaxis,)
                 for axis in reversed(sorted(set(reduceaxis))):

--- a/postpic/datareader/dummy.py
+++ b/postpic/datareader/dummy.py
@@ -132,7 +132,7 @@ class Dummyreader(Dumpreader_ifc):
 
     def simextent(self, axis):
         g = self.grid(None, axis)
-        return np.asfarray([g[0], g[-1]])
+        return np.asarray([g[0], g[-1]], dtype=np.float64)
 
     def gridnode(self, key, axis):
         '''

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -946,7 +946,7 @@ def _linear_phase(field, dx, phi0=0.0):
 
     # calculate linear phase
     # arg = sum([dx[i]*mesh[i] for i in dx.keys()])
-    arg_expr = '+'.join('({}*k{})'.format(repr(v), i) for i, v in dx.items())
+    arg_expr = '+'.join('({:}*k{})'.format(v, i) for i, v in dx.items())
 
     if transform_state is True:
         exp_ikdx_expr = 'exp(1j * ({arg} + phi0))'.format(arg=arg_expr)
@@ -1057,7 +1057,7 @@ def _kspace_propagate_generator(kspace, dt, moving_window_vect=None,
         # m = kspace.matrix.copy()
         # m[sum(k*dx for k, dx in zip(kspace.meshgrid(), moving_window_vect)) < 0.0] = 0.0
         # kspace = kspace.replace_data(m)
-        arg_expr = '+'.join('({}*k{})'.format(repr(v), i)
+        arg_expr = '+'.join('({:}*k{})'.format(v, i)
                             for i, v
                             in enumerate(moving_window_vect))
         numexpr_vars = dict(kspace=kspace)

--- a/postpic/helper.py
+++ b/postpic/helper.py
@@ -1039,7 +1039,7 @@ def _kspace_propagate_generator(kspace, dt, moving_window_vect=None,
             raise ValueError("Argument moving_window_vect has the wrong length. "
                              "Please make sure that len(moving_window_vect) == kspace.dimensions.")
 
-        moving_window_vect = np.asfarray(moving_window_vect)
+        moving_window_vect = np.asarray(moving_window_vect, dtype=np.float64)
         moving_window_vect /= npl.norm(moving_window_vect)
         moving_window_dict = dict(enumerate([dz*x for x in moving_window_vect]))
 

--- a/test/test_datahandling.py
+++ b/test/test_datahandling.py
@@ -612,8 +612,8 @@ class TestField(unittest.TestCase):
         print('type(a.matrix)', type(a.matrix))
         self.assertTrue(np.isclose(a, b))
 
-        b = self.f2d_fine.integrate(method=scipy.integrate.simps)
-        c = self.f2d_fine.integrate(method=scipy.integrate.trapz)
+        b = self.f2d_fine.integrate(method=scipy.integrate.simpson)
+        c = self.f2d_fine.integrate(method=scipy.integrate.trapezoid)
 
         self.assertTrue(np.isclose(b, 0))
         self.assertTrue(np.isclose(c, 0))


### PR DESCRIPTION
* Scipy 1.14.0 removed deprecated scipy.integrate.trapz and scipy.integrate.simps functions
* numexpr introduced (in version 2.9?) sanity check rules, which result in invalid control character errors if ignored.
* numpy 2.0 changed __array_ufunc__ such that axis=None is possible.
* numpy 2.0 has removed np.asfarray