### PR TITLE
Migrated most of setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,69 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython>=0.18", "numpy>1.8", "versioneer"]
+requires = ["setuptools", "wheel", "Cython>=0.18", "numpy>1.8", "versioneer[toml]"] #war ohne toml
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "postpic"
+dynamic = ["version"]
+license= {text =  "GPLv3+"}
+description = "The open source particle-in-cell post processor."
+readme = "README.md"
+authors = [{ name = "Stephan Kuschel", email = "stephan.kuschel@gmail.de" }]
+keywords = ['PIC', 'particle-in-cell', 'plasma', 'physics', 'plasma physics',
+                  'laser', 'laser plasma', 'particle acceleration']
+dependencies = [
+    'matplotlib>=3.0', # ndarray.tobytes was introduced in np 1.9 and workaround in vtk routines
+                        # does not work for python 2 war 1.3
+    'matplotlib<=3.10; python_version=="3.10"',
+    'numpy>=1.8', 
+    'scipy>=1.6', 'scipy<=1.15;python_version=="3.10"',
+    'scipy<=1.17;python_version<="3.11"',
+    'future',
+    'urllib3',
+    'contourpy<= 1.3.1; python_version=="3.10"',
+    'numexpr',
+    'cython>=0.18',
+    'packaging']
+
+classifiers=[
+          'Development Status :: 4 - Beta',
+          'Intended Audience :: Science/Research',
+          'Intended Audience :: Developers',
+          'Topic :: Scientific/Engineering',
+          'Topic :: Scientific/Engineering :: Astronomy',
+          'Topic :: Scientific/Engineering :: Physics',
+          'Topic :: Scientific/Engineering :: Visualization',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Operating System :: Unix',
+          'Operating System :: MacOS',
+          'Operating System :: Microsoft :: Windows',
+          'Operating System :: POSIX',
+          'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)']
+
+[project.optional-dependencies]
+h5_reader_openpmd = ['h5py']
+sdf_support_epoch = ['sdf']
+pypng_png_reading = ['pypng']
+pillow_read_other_image_files = ['pillow']
+phase_unwrapping_routines = ['scikit-image']
+
+[project.urls]
+Homepage = "https://github.com/skuschel/postpic"
+
+[tool.setuptools.packages.find]
+include = ["postpic*"]
+namespaces = false
+
+#[tool.setuptools]
+#include-package-data = true
+
+
+[tool.versioneer]
+VCS = "git"
+style = "pep440"
+versionfile_source = "postpic/_version.py"
+versionfile_build = "postpic/_version.py"
+tag_prefix = "v"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = postpic/_version.py
-versionfile_build = postpic/_version.py
-tag_prefix = v
-
 [build_sphinx]
 source-dir = doc/source
 build-dir  = doc/build

--- a/setup.py
+++ b/setup.py
@@ -25,52 +25,10 @@ import os
 import versioneer
 
 
-setup(name='postpic',
-      version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass(),
-      include_package_data = True,
-      author='Stephan Kuschel',
-      author_email='stephan.kuschel@gmail.de',
-      description='The open source particle-in-cell post processor.',
-      url='https://github.com/skuschel/postpic',
-      packages=find_packages(include=['postpic*']),
-      ext_modules = cythonize("postpic/particles/_particlestogrid.pyx"),
-      include_dirs = [numpy.get_include()],
-      license='GPLv3+',
-      setup_requires=['cython>=0.18', 'numpy>=1.8'],
-      install_requires=['matplotlib>=1.3',
-                        # ndarray.tobytes was introduced in np 1.9 and workaround in vtk routines
-                        # does not work for python 2
-                        'numpy>=1.8', 'numpy>=1.9;python_version<"3.0"',
-                        'scipy>=1.6', 'scipy<= 1.15;python_version=="3.10"',
-                        'future', 'urllib3',
-                        'contourpy <= 1.3.1; python_version=="3.10"', 'numexpr',
-                        'cython>=0.18', 'functools32;python_version<"3.0"',
-                        'packaging'],
-      extras_require = {
-        'h5 reader for openPMD support':  ['h5py'],
-        'sdf support for EPOCH reader':  ['sdf'],
-        'PyPNG read png files': ['pypng'],
-        'Pillow to read other image files': ['pillow'],
-        'Phase unwrapping routines': ['scikit-image']},
-      keywords = ['PIC', 'particle-in-cell', 'plasma', 'physics', 'plasma physics',
-                  'laser', 'laser plasma', 'particle acceleration'],
-      classifiers=[
-          'Development Status :: 4 - Beta',
-          'Intended Audience :: Science/Research',
-          'Intended Audience :: Developers',
-          'Topic :: Scientific/Engineering',
-          'Topic :: Scientific/Engineering :: Astronomy',
-          'Topic :: Scientific/Engineering :: Physics',
-          'Topic :: Scientific/Engineering :: Visualization',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Operating System :: Unix',
-          'Operating System :: MacOS',
-          'Operating System :: Microsoft :: Windows',
-          'Operating System :: POSIX',
-          'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)']
-      )
+setup(
+        cmdclass=versioneer.get_cmdclass(),
+        ext_modules = cythonize("postpic/particles/_particlestogrid.pyx"),
+        include_dirs = [numpy.get_include()],
+        include_package_data = True
+)
+      

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ import versioneer
 
 
 setup(
+        version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
         ext_modules = cythonize("postpic/particles/_particlestogrid.pyx"),
         include_dirs = [numpy.get_include()],


### PR DESCRIPTION
Not all is currently possible to migrate, especially ext_modules for cython. But most is moved over to pyproject.toml. Also removed some python 2 references/dependencies in the setup.