### PR TITLE
Fixed an issue, where postpic crashes when there is only one macroparticle

### DIFF
--- a/postpic/datareader/openPMDh5.py
+++ b/postpic/datareader/openPMDh5.py
@@ -92,7 +92,10 @@ class OpenPMDreader(Dumpreader_ifc):
             ret = np.float64(record.attrs['value']) * record.attrs['unitSI']
         else:
             # array data
-            ret = np.float64(record[()]) * record.attrs['unitSI']
+            if len(record[()]) == 1:
+                ret = np.float64(record[()][0]) * record.attrs['unitSI']
+            else:
+                ret = np.float64(record[()]) * record.attrs['unitSI']
         return ret
 
     def gridoffset(self, key, axis):

--- a/postpic/datareader/openPMDh5.py
+++ b/postpic/datareader/openPMDh5.py
@@ -91,7 +91,7 @@ class OpenPMDreader(Dumpreader_ifc):
             # constant data (a single int or float)
             ret = np.float64(record.attrs['value']) * record.attrs['unitSI']
         else:
-            # array data
+            # array data. If there is only one particle in the array, make it a scalar
             if len(record[()]) == 1:
                 ret = np.float64(record[()][0]) * record.attrs['unitSI']
             else:

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -237,9 +237,7 @@ class _SingleSpecies(object):
         # bools = np.array([idx in condition for idx in self.ID()])
         # but benchmarked to be 1500 times faster :)
         condition.sort()
-        ids = self.id()
-        if not isinstance(ids, np.ndarray):
-            ids = [ids]
+        ids = np.atleast_1d(self.id())
         idx = np.searchsorted(condition, ids)
         idx[idx == len(condition)] = 0
         bools = condition[idx] == ids
@@ -277,9 +275,7 @@ class _SingleSpecies(object):
         for key in self._atomicprops:
             try:
                 # len(3) will yield a TypeError, len([3]) returns 1
-                value = self._readatomic(key)
-                if not isinstance(value, np.ndarray):
-                    value = [value]
+                value = np.atleast_1d(self._readatomic(key))
                 ret = len(value)
                 break
             except (TypeError, KeyError):

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -239,7 +239,10 @@ class _SingleSpecies(object):
         condition.sort()
         ids = self.id()
         idx = np.searchsorted(condition, ids)
-        idx[idx == len(condition)] = 0
+        if isinstance(idx, np.ndarray):
+            idx[idx == len(condition)] = 0
+        else:
+            idx = [] 
         bools = condition[idx] == ids
         return self._compress_bool(bools)
 
@@ -1272,7 +1275,8 @@ class ParticleHistory(object):
         Indexorder of returned array: [particle_idx][scalarf_idx, collection_idx]
         '''
         particlelist = [list() for _ in range(len(self.ids))]
-        for dr in self.sr:
+        from tqdm.notebook import tqdm
+        for dr in tqdm(self.sr):
             ids, scalars = self._collectfromdump(dr, scalarfs)
             for k in range(len(ids)):
                 i = self._id2i[ids[k]]

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -243,7 +243,6 @@ class _SingleSpecies(object):
         idx = np.searchsorted(condition, ids)
         idx[idx == len(condition)] = 0
         bools = condition[idx] == ids
-        print(bools)
         return self._compress_bool(bools)
 
     def uncompress(self):

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -242,7 +242,7 @@ class _SingleSpecies(object):
         if isinstance(idx, np.ndarray):
             idx[idx == len(condition)] = 0
         else:
-            idx = [] 
+            idx = []
         bools = condition[idx] == ids
         return self._compress_bool(bools)
 

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -238,12 +238,12 @@ class _SingleSpecies(object):
         # but benchmarked to be 1500 times faster :)
         condition.sort()
         ids = self.id()
+        if not isinstance(ids, np.ndarray):
+            ids = [ids]
         idx = np.searchsorted(condition, ids)
-        if isinstance(idx, np.ndarray):
-            idx[idx == len(condition)] = 0
-        else:
-            idx = []
+        idx[idx == len(condition)] = 0
         bools = condition[idx] == ids
+        print(bools)
         return self._compress_bool(bools)
 
     def uncompress(self):
@@ -278,7 +278,10 @@ class _SingleSpecies(object):
         for key in self._atomicprops:
             try:
                 # len(3) will yield a TypeError, len([3]) returns 1
-                ret = len(self._readatomic(key))
+                value = self._readatomic(key)
+                if not isinstance(value, np.ndarray):
+                    value = [value]
+                ret = len(value)
                 break
             except (TypeError, KeyError):
                 pass

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -1277,8 +1277,7 @@ class ParticleHistory(object):
         Indexorder of returned array: [particle_idx][scalarf_idx, collection_idx]
         '''
         particlelist = [list() for _ in range(len(self.ids))]
-        from tqdm.notebook import tqdm
-        for dr in tqdm(self.sr):
+        for dr in self.sr:
             ids, scalars = self._collectfromdump(dr, scalarfs)
             for k in range(len(ids)):
                 i = self._id2i[ids[k]]


### PR DESCRIPTION
When there is only on macroparticle (e. g. after filtering), postpic may crash. This is because if there is only on particle, the code gets an integer instead of an array. This also led to len() calculating the number in such cases wrongly, returning zero albeit there being on element.

Also added a tqdm (for notebooks) to exporttoh5().