### PR TITLE
Add tqdm to particle history collect

### DIFF
--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -1275,7 +1275,7 @@ class ParticleHistory(object):
         try:
             from tqdm.auto import tqdm
             itera = tqdm(self.sr)
-        except ModuleNotFoundError:
+        except ImportError:
             itera = self.sr
         for dr in itera:
             ids, scalars = self._collectfromdump(dr, scalarfs)

--- a/postpic/particles/particles.py
+++ b/postpic/particles/particles.py
@@ -1272,7 +1272,12 @@ class ParticleHistory(object):
         Indexorder of returned array: [particle_idx][scalarf_idx, collection_idx]
         '''
         particlelist = [list() for _ in range(len(self.ids))]
-        for dr in self.sr:
+        try:
+            from tqdm.auto import tqdm
+            itera = tqdm(self.sr)
+        except ModuleNotFoundError:
+            itera = self.sr
+        for dr in itera:
             ids, scalars = self._collectfromdump(dr, scalarfs)
             for k in range(len(ids)):
                 i = self._id2i[ids[k]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ sdf_support_epoch = ['sdf']
 pypng_png_reading = ['pypng']
 pillow_read_other_image_files = ['pillow']
 phase_unwrapping_routines = ['scikit-image']
+tqdm_particle_history = ['tqdm']
 
 [project.urls]
 Homepage = "https://github.com/skuschel/postpic"


### PR DESCRIPTION
As using particle history may take pretty long, especially for long simulations, a progess bar via tqdm is added. It works for both console and jupyterlab. If tqdm is not installed, no progessbar will be used. This is done so that tqdm is not mandatory.